### PR TITLE
fix: next 13.5 router mocks

### DIFF
--- a/web/jest.setup.ts
+++ b/web/jest.setup.ts
@@ -4,6 +4,12 @@ import 'mock-match-media/jest-setup';
 
 jest.mock('next/router', () => require('next-router-mock'));
 
+jest.mock(
+  'next/dist/shared/lib/router-context',
+  () => jest.requireActual('next/dist/shared/lib/router-context.shared-runtime'),
+  { virtual: true }
+);
+
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
   unobserve: jest.fn(),


### PR DESCRIPTION
## Changes
- Fixes the broken test CI until `next-router-mock` v13.5 support is released
https://github.com/scottrippey/next-router-mock/pull/105