### PR TITLE
Clarify correct env vars in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,24 @@
 # [REQUIRED] - the connection URL for the application database.
-DATABASE_URL=postgresql://granola:systems@localhost:5432/db
+DATABASE_URL=postgresql://granola:systems@127.0.0.1:5432/db
 
 # [REQUIRED] - the connection URL for the archive database.
-ARCHIVE_DATABASE_URL=postgresql://granola:systems@localhost:5432/db
+# ARCHIVE_DATABASE_URL=postgresql://granola:systems@127.0.0.1:5432/db
 
 # [REQUIRED] - origins allowed to make cross-site requests.
 # Use "*" to allow from anywhere.
-# to configure multiple origins use 'whitespace' as delimiter, e.g. "http://localhost:8080 http://my-web.com"
-# SERVER_ALLOWED_ORIGINS="http://localhost:8080 http://my-web.com"
+# to configure multiple origins use 'whitespace' as delimiter, e.g. "http://127.0.0.1:8080 http://my-web.com"
+# SERVER_ALLOWED_ORIGINS="http://127.0.0.1:8080 http://my-web.com"
 SERVER_ALLOWED_ORIGINS="*"
 
 # [REQUIRED] - the mina network
 # valid options are: "mainnet" | "devnet" | "berkeley"
-MINA_NETWORK="mainnet"
+MINA_NETWORK=mainnet
 
 # [OPTIONAL] - overrides the ledger storage location
 # LEDGER_STORAGE_PATH="./server/tmp"
 
 # [REQUIRED] - the base URL for the API.
-API_BASE_URL=http://localhost:8080
+API_BASE_URL=http://127.0.0.1:8080
 
 # [OPTIONAL] - defaults to 'development', or set to 'staging' or 'production'.
 RELEASE_STAGE=production
@@ -29,10 +29,8 @@ RELEASE_STAGE=production
 NEXT_PUBLIC_RELEASE_STAGE=$RELEASE_STAGE
 NEXT_PUBLIC_API_BASE_URL=$API_BASE_URL
 
-# FLAGS
-
 # [OPTIONAL] - builds next as a standalone. [used in docker]
-NEXT_ENV_DOCKER=1
+# NEXT_ENV_DOCKER=1
 
 # [OPTIONAL] - skips .env validation [useful for testing and docker].
-SKIP_ENV_VALIDATION=1
+# SKIP_ENV_VALIDATION=1

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -43,6 +43,6 @@ COPY --from=builder /etc/group /etc/group
 COPY --from=builder /app/server/target/release/mina-ocv-server /app/mina-ocv-server
 WORKDIR /app
 USER mina:mina
-ENV RUST_LOG "mina_governance_server=debug,tower_http=trace"
+
 # start the server
 CMD ["./mina-ocv-server"]


### PR DESCRIPTION
This also undoes some accidental pushes direct to 'main' that GitHub allowed me to perform. (Not sure why.)