### PR TITLE
Archive Node Tools

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,1 +1,2 @@
 /server/
+target

--- a/tools/DownloadArchiveDump.hs
+++ b/tools/DownloadArchiveDump.hs
@@ -28,7 +28,7 @@ import Tools.Lib.ArchiveDump
   )
 import Tools.Lib.Fetchers (fetchArchiveDump, fetchDatabaseDumpIndex)
 import Network.Curl (CurlOption, CurlResponse_ (respBody), URLString, curlGetResponse_, withCurlDo)
-import System.Directory (doesFileExist, removeFile)
+import System.Directory (doesFileExist, removeFile, doesDirectoryExist, createDirectory)
 import System.Exit (ExitCode (ExitSuccess), exitSuccess, exitWith)
 import System.IO (IOMode (WriteMode), hClose, hPutStrLn, openBinaryFile, stdout, withBinaryFile, withFile)
 import Text.Megaparsec
@@ -108,6 +108,8 @@ main = do
   putStrLn $ "donwloading archive dump " ++ targetKey ++ "..."
   archiveDumpCompressed <- fetchArchiveDump targetKey
   let archiveDump = decompress . fromStrict $ archiveDumpCompressed
+
+  createDirectory "database_dumps/"
 
   putStrLn "writing archive file..."
   withBinaryFile

--- a/tools/DownloadArchiveDump.hs
+++ b/tools/DownloadArchiveDump.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module DownloadArchiveDump where
+module Tools.DownloadArchiveDump where
 
 import Codec.Archive.Tar (extract)
 import Codec.Compression.GZip (decompress)
@@ -22,11 +22,11 @@ import Data.Void (Void)
 import Database.PostgreSQL.Simple (close, connectPostgreSQL, execute_)
 import Database.Postgres.Temp (Config (..), DirectoryType (Permanent), defaultConfig, toConnectionString, with)
 import Distribution.Compat.CharParsing (digit)
-import Lib.ArchiveDump
+import Tools.Lib.ArchiveDump
   ( ArchiveDump (ArchiveDump, dumpMetadata),
     parseDumps, MinaNetwork(..), ArchiveDumpMetadata (dumpNetwork),
   )
-import Lib.Fetchers (fetchArchiveDump, fetchDatabaseDumpIndex)
+import Tools.Lib.Fetchers (fetchArchiveDump, fetchDatabaseDumpIndex)
 import Network.Curl (CurlOption, CurlResponse_ (respBody), URLString, curlGetResponse_, withCurlDo)
 import System.Directory (doesFileExist, removeFile)
 import System.Exit (ExitCode (ExitSuccess), exitSuccess, exitWith)

--- a/tools/DownloadArchiveDump.hs
+++ b/tools/DownloadArchiveDump.hs
@@ -22,11 +22,11 @@ import Data.Void (Void)
 import Database.PostgreSQL.Simple (close, connectPostgreSQL, execute_)
 import Database.Postgres.Temp (Config (..), DirectoryType (Permanent), defaultConfig, toConnectionString, with)
 import Distribution.Compat.CharParsing (digit)
-import Tools.Lib.ArchiveDump
+import Lib.ArchiveDump
   ( ArchiveDump (ArchiveDump, dumpMetadata),
     parseDumps, MinaNetwork(..), ArchiveDumpMetadata (dumpNetwork),
   )
-import Tools.Lib.Fetchers (fetchArchiveDump, fetchDatabaseDumpIndex)
+import Lib.Fetchers (fetchArchiveDump, fetchDatabaseDumpIndex)
 import Network.Curl (CurlOption, CurlResponse_ (respBody), URLString, curlGetResponse_, withCurlDo)
 import System.Directory (doesFileExist, removeFile, doesDirectoryExist, createDirectory)
 import System.Exit (ExitCode (ExitSuccess), exitSuccess, exitWith)

--- a/tools/DownloadArchiveDump.hs
+++ b/tools/DownloadArchiveDump.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module DownloadArchiveDump where
+
+import Codec.Archive.Tar (extract)
+import Codec.Compression.GZip (decompress)
+import Control.Monad (forever, unless, void, when)
+import Control.Monad.Catch (ExitCase (ExitCaseAbort), bracket)
+import Data.ByteString (ByteString, hPut, writeFile)
+import qualified Data.ByteString as Prelude
+import Data.ByteString.Lazy (fromStrict, toStrict)
+import Data.Data (DataRep)
+import Data.Either (rights)
+import Data.Functor ((<&>))
+import Data.Function ((&))
+import Data.List (isInfixOf, sort, sortBy)
+import Data.Maybe (catMaybes, isJust, mapMaybe)
+import Data.Monoid (Last (..))
+import Data.Void (Void)
+import Database.PostgreSQL.Simple (close, connectPostgreSQL, execute_)
+import Database.Postgres.Temp (Config (..), DirectoryType (Permanent), defaultConfig, toConnectionString, with)
+import Distribution.Compat.CharParsing (digit)
+import Lib.ArchiveDump
+  ( ArchiveDump (ArchiveDump, dumpMetadata),
+    parseDumps, MinaNetwork(..), ArchiveDumpMetadata (dumpNetwork),
+  )
+import Lib.Fetchers (fetchArchiveDump, fetchDatabaseDumpIndex)
+import Network.Curl (CurlOption, CurlResponse_ (respBody), URLString, curlGetResponse_, withCurlDo)
+import System.Directory (doesFileExist, removeFile)
+import System.Exit (ExitCode (ExitSuccess), exitSuccess, exitWith)
+import System.IO (IOMode (WriteMode), hClose, hPutStrLn, openBinaryFile, stdout, withBinaryFile, withFile)
+import Text.Megaparsec
+  ( MonadParsec (try),
+    Parsec,
+    many,
+    runParser,
+    (<|>),
+  )
+import Text.Megaparsec.Char (char, digitChar, string)
+import Text.XML.Light (Attr, CData (cdData), Content (Elem, Text), Element (Element, elAttribs, elContent, elName), QName (qName), parseXML)
+import qualified Data.List as List
+
+getListBucketsResult :: Content -> [Content]
+getListBucketsResult = \case
+  Elem (Element name attrs content line) ->
+    if qName name == "ListBucketResult"
+      then drop 4 content
+      else []
+  _ -> []
+
+getDumpKeys :: [Content] -> [String]
+getDumpKeys =
+  mapMaybe
+    ( \content -> do
+        keyElement <- case content of
+          Elem (Element name attrs content line) ->
+            if qName name == "Contents"
+              then Just $ head content
+              else Nothing
+
+        textElement <- case keyElement of
+          Elem (Element name attrs content line) ->
+            if qName name == "Key"
+              then Just $ head content
+              else Nothing
+          _ -> Nothing
+
+        case textElement of
+          Text cd ->
+            let dumpName = cdData cd
+             in if List.any ((`isInfixOf` dumpName) . show) [Mainnet, Devnet, Berkeley]
+                  then Just dumpName
+                  else Nothing
+          _ -> Nothing
+    )
+
+main :: IO ()
+main = do
+  putStr "input desired network: "
+  network :: MinaNetwork <- getLine <&> read
+  putStrLn "getting database backup keys..."
+  keysByDate <- fetchDatabaseDumpIndex >>= 
+    ( \index -> (index !! 1)
+    & getListBucketsResult
+    & getDumpKeys
+    & parseDumps
+    & filter (\dump -> network ==
+      (dumpNetwork . dumpMetadata) dump)
+    & sort
+    & return
+    )
+  let (ArchiveDump targetKey metadata) = last keysByDate
+  let archiveDumpTar = "database_dumps/" ++ targetKey
+  let archiveDumpFilename = take (length archiveDumpTar - length (".tar.gz" :: String)) archiveDumpTar
+
+  archiveDumpExists <- doesFileExist archiveDumpFilename
+  when archiveDumpExists $ do
+    putStr
+      ( "archive dump \""
+          ++ archiveDumpFilename
+          ++ "\" exists, would you like to overwrite? (y/N): "
+      )
+    resp <- getLine
+    unless (resp == "y") exitSuccess
+
+  putStrLn $ "donwloading archive dump " ++ targetKey ++ "..."
+  archiveDumpCompressed <- fetchArchiveDump targetKey
+  let archiveDump = decompress . fromStrict $ archiveDumpCompressed
+
+  putStrLn "writing archive file..."
+  withBinaryFile
+    archiveDumpTar
+    WriteMode
+    (\handle -> do hPut handle (toStrict archiveDump))
+
+  putStrLn "extracting archive dump..."
+  extract "database_dumps/" archiveDumpTar
+
+  removeFile archiveDumpTar

--- a/tools/Lib/ArchiveDump.hs
+++ b/tools/Lib/ArchiveDump.hs
@@ -1,4 +1,4 @@
-module Tools.Lib.ArchiveDump where
+module Lib.ArchiveDump where
 import Text.Megaparsec (Parsec, MonadParsec (try), (<|>), many, runParser)
 import Data.Void (Void)
 import Text.Megaparsec.Char (string, digitChar, char)

--- a/tools/Lib/ArchiveDump.hs
+++ b/tools/Lib/ArchiveDump.hs
@@ -1,4 +1,4 @@
-module Lib.ArchiveDump where
+module Tools.Lib.ArchiveDump where
 import Text.Megaparsec (Parsec, MonadParsec (try), (<|>), many, runParser)
 import Data.Void (Void)
 import Text.Megaparsec.Char (string, digitChar, char)

--- a/tools/Lib/ArchiveDump.hs
+++ b/tools/Lib/ArchiveDump.hs
@@ -1,0 +1,73 @@
+module Lib.ArchiveDump where
+import Text.Megaparsec (Parsec, MonadParsec (try), (<|>), many, runParser)
+import Data.Void (Void)
+import Text.Megaparsec.Char (string, digitChar, char)
+import Data.Maybe (mapMaybe)
+import qualified Text.ParserCombinators.ReadPrec
+
+type Parser = Parsec Void String
+
+data ArchiveDump = ArchiveDump
+  { dumpName :: String
+  , dumpMetadata :: ArchiveDumpMetadata
+  } deriving (Show, Eq)
+instance Ord ArchiveDump where
+  compare (ArchiveDump _ meta1) (ArchiveDump _ meta2) =
+    meta1 `compare` meta2
+
+parseArchiveDumpMetadata :: String -> Maybe ArchiveDump
+parseArchiveDumpMetadata dumpName = do
+  dumpMetadata <- case runParser dumpParser "" dumpName of
+    Left _ -> Nothing
+    Right metadata -> Just metadata
+  pure $ ArchiveDump dumpName dumpMetadata
+
+parseDumps :: [String] -> [ArchiveDump]
+parseDumps = mapMaybe parseArchiveDumpMetadata
+
+data MinaNetwork
+  = Mainnet
+  | Devnet
+  | Berkeley
+  deriving (Eq, Ord, Enum, Read)
+instance Show MinaNetwork where
+  show :: MinaNetwork -> String
+  show Mainnet = "mainnet"
+  show Devnet = "devnet"
+  show Berkeley = "berkeley"
+
+data ArchiveDumpMetadata = 
+  ArchiveDumpMetadata
+  { dumpNetwork :: MinaNetwork
+  , year :: Int
+  ,  month :: Int
+  , day :: Int
+  } deriving (Show, Eq)
+
+instance Ord ArchiveDumpMetadata where
+  compare d1 d2
+    | year d1 /= year d2 = compare (year d1) (year d2)
+    | month d1 /= month d2 = compare (month d1) (month d2)
+    | otherwise = compare (day d1) (day d2)
+
+minaNetwork :: Parser MinaNetwork
+minaNetwork =
+  try (Devnet <$ string "devnet-archive-dump-") 
+  <|> (Mainnet <$ string "mainnet-archive-dump-")
+  <|> (Mainnet <$ string "archive-dump-")
+  <|> (Berkeley <$ string "berkeley-archive-dump-")
+
+dumpDate :: Parser (Int, Int, Int)
+dumpDate = do
+  year <- many digitChar
+  char '-'
+  month <- many digitChar
+  char '-'
+  day <- many digitChar
+  pure (read year, read month, read day)
+
+dumpParser :: Parser ArchiveDumpMetadata
+dumpParser = do
+  network <- minaNetwork
+  (year, month, day) <- dumpDate
+  pure $ ArchiveDumpMetadata network year month day

--- a/tools/Lib/DatabaseCommands.hs
+++ b/tools/Lib/DatabaseCommands.hs
@@ -1,0 +1,6 @@
+module Lib.DatabaseCommands where
+import System.Process (createProcess, CreateProcess (CreateProcess), callCommand)
+
+restoreDatabaseBackup :: String -> IO ()
+restoreDatabaseBackup archiveKey = do
+    callCommand $ "psql -h localhost -p 5432 -U $USER -d postgres -f " ++ archiveKey

--- a/tools/Lib/DatabaseCommands.hs
+++ b/tools/Lib/DatabaseCommands.hs
@@ -1,4 +1,4 @@
-module Tools.Lib.DatabaseCommands where
+module Lib.DatabaseCommands where
 import System.Process (createProcess, CreateProcess (CreateProcess), callCommand)
 
 restoreDatabaseBackup :: String -> IO ()

--- a/tools/Lib/DatabaseCommands.hs
+++ b/tools/Lib/DatabaseCommands.hs
@@ -1,4 +1,4 @@
-module Lib.DatabaseCommands where
+module Tools.Lib.DatabaseCommands where
 import System.Process (createProcess, CreateProcess (CreateProcess), callCommand)
 
 restoreDatabaseBackup :: String -> IO ()

--- a/tools/Lib/Fetchers.hs
+++ b/tools/Lib/Fetchers.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module Lib.Fetchers where
+import Text.XML.Light (Content, parseXML)
+import Network.Curl (CurlResponse_ (respBody), withCurlDo, curlGetResponse_, URLString, CurlOption)
+import Data.ByteString ( ByteString )
+
+databaseDumpIndexURL :: URLString
+databaseDumpIndexURL = "https://storage.googleapis.com/mina-archive-dumps/"
+
+curlOptions :: [CurlOption]
+curlOptions = []
+
+
+fetchDatabaseDumpIndex :: IO [Content]
+fetchDatabaseDumpIndex = withCurlDo $ do
+  response :: CurlResponse_ [(String, String)] String 
+    <- curlGetResponse_ databaseDumpIndexURL curlOptions
+
+  return . parseXML . respBody $ response
+
+fetchArchiveDump :: String -> IO ByteString
+fetchArchiveDump key = withCurlDo $ do
+  response :: CurlResponse_ [(String, String)] ByteString 
+    <- curlGetResponse_ (databaseDumpIndexURL ++ key) curlOptions
+
+  return (respBody response)

--- a/tools/Lib/Fetchers.hs
+++ b/tools/Lib/Fetchers.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-module Tools.Lib.Fetchers where
+module Lib.Fetchers where
 import Text.XML.Light (Content, parseXML)
 import Network.Curl (CurlResponse_ (respBody), withCurlDo, curlGetResponse_, URLString, CurlOption)
 import Data.ByteString ( ByteString )

--- a/tools/Lib/Fetchers.hs
+++ b/tools/Lib/Fetchers.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-module Lib.Fetchers where
+module Tools.Lib.Fetchers where
 import Text.XML.Light (Content, parseXML)
 import Network.Curl (CurlResponse_ (respBody), withCurlDo, curlGetResponse_, URLString, CurlOption)
 import Data.ByteString ( ByteString )

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,8 +3,8 @@ Archive Node Developer Tools
 <hr>
 
 - Download Archive Dump
-* `nix-shell tools/shell.nix --command runghc tools/DownloadArchiveDump.hs`
+* `nix-shell shell.nix --command 'runghc DownloadArchiveDump.hs'`
 
 - Temporary Archive Database
-* `nix-shell tools/shell.nix --command runghc toold/TemporaryArchiveDatabase.hs`
+* `nix-shell shell.nix --command 'runghc TemporaryArchiveDatabase.hs'`
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,10 @@
+Archive Node Developer Tools
+
+<hr>
+
+- Download Archive Dump
+* `nix-shell tools/shell.nix --command runghc tools/DownloadArchiveDump.hs`
+
+- Temporary Archive Database
+* `nix-shell tools/shell.nix --command runghc toold/TemporaryArchiveDatabase.hs`
+

--- a/tools/TemporaryArchiveDatabase.hs
+++ b/tools/TemporaryArchiveDatabase.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module TemporaryArchiveDatabase where
+module Tools.TemporaryArchiveDatabase where
 
 import Control.Monad (forever, guard, void, when)
 import Control.Monad.Catch (bracket)
@@ -24,9 +24,9 @@ import Database.Postgres.Temp (CommandLineArgs (keyBased), Config (connectionOpt
 import System.Directory
     ( getDirectoryContents, removeDirectoryRecursive, removeDirectory )
 import System.IO (IOMode (ReadMode), withFile)
-import Lib.ArchiveDump
+import Tools.Lib.ArchiveDump
     ( ArchiveDump(ArchiveDump, dumpMetadata), parseDumps, MinaNetwork, ArchiveDumpMetadata (dumpNetwork) )
-import Lib.DatabaseCommands (restoreDatabaseBackup)
+import Tools.Lib.DatabaseCommands (restoreDatabaseBackup)
 import System.Environment (getEnv)
 import Data.Kind (Type)
 import Data.Int (Int64)

--- a/tools/TemporaryArchiveDatabase.hs
+++ b/tools/TemporaryArchiveDatabase.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Tools.TemporaryArchiveDatabase where
+module TemporaryArchiveDatabase where
 
 import Control.Monad (forever, guard, void, when)
 import Control.Monad.Catch (bracket)
@@ -24,9 +24,9 @@ import Database.Postgres.Temp (CommandLineArgs (keyBased), Config (connectionOpt
 import System.Directory
     ( getDirectoryContents, removeDirectoryRecursive, removeDirectory )
 import System.IO (IOMode (ReadMode), withFile)
-import Tools.Lib.ArchiveDump
+import Lib.ArchiveDump
     ( ArchiveDump(ArchiveDump, dumpMetadata), parseDumps, MinaNetwork, ArchiveDumpMetadata (dumpNetwork) )
-import Tools.Lib.DatabaseCommands (restoreDatabaseBackup)
+import Lib.DatabaseCommands (restoreDatabaseBackup)
 import System.Environment (getEnv)
 import Data.Kind (Type)
 import Data.Int (Int64)

--- a/tools/TemporaryArchiveDatabase.hs
+++ b/tools/TemporaryArchiveDatabase.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module TemporaryArchiveDatabase where
+
+import Control.Monad (forever, guard, void, when)
+import Control.Monad.Catch (bracket)
+import Data.ByteString (hGetContents)
+import Data.List (sort)
+import Data.Map.Strict (fromList)
+import Data.Monoid (Last (..))
+import Data.String (IsString (fromString))
+import Data.Text.Short (toString)
+import Database.PostgreSQL.Simple (close, connectPostgreSQL, execute_)
+import qualified Database.PostgreSQL.Simple as PG
+import Database.PostgreSQL.Simple.Options (Options (Options, dbname, host, user), defaultOptions)
+import Database.PostgreSQL.Simple.Types (Query (..))
+import Database.Postgres.Temp (CommandLineArgs (keyBased), Config (connectionOptions, dataDirectory, initDbConfig, logger, port, postgresConfig, postgresConfigFile), DirectoryType (Permanent), Event, ProcessConfig (ProcessConfig, commandLine), startConfig, toConnectionString, with, withConfig)
+import System.Directory
+    ( getDirectoryContents, removeDirectoryRecursive, removeDirectory )
+import System.IO (IOMode (ReadMode), withFile)
+import Lib.ArchiveDump
+    ( ArchiveDump(ArchiveDump, dumpMetadata), parseDumps, MinaNetwork, ArchiveDumpMetadata (dumpNetwork) )
+import Lib.DatabaseCommands (restoreDatabaseBackup)
+import System.Environment (getEnv)
+import Data.Kind (Type)
+import Data.Int (Int64)
+import Control.Monad.Cont (MonadIO (liftIO))
+import Data.Functor ((<&>))
+
+databaseLogger :: Event -> IO ()
+databaseLogger = print
+
+databaseConfig :: IO Config
+databaseConfig = do
+  user <- getEnv "USER"
+  pure $ mempty
+    { logger = mempty, -- pure databaseLogger
+      postgresConfigFile =
+        [ ("log_min_messages", "warning"),
+          ("log_min_error_statement", "error"),
+          ("log_min_duration_statement", "100  # ms"),
+          ("log_connections", "on"),
+          ("log_disconnections", "on"),
+          ("log_duration", "on"),
+          ("#log_line_prefix", "'[] '"),
+          ("log_timezone", "'UTC'"),
+          ("log_statement", "'all'"),
+          ("log_directory", "'pg_log'"),
+          ("log_filename", "'postgresql-%Y-%m-%d_%H%M%S.log'"),
+          ("logging_collector", "on"),
+          ("log_min_error_statement", "error")
+        ],
+      initDbConfig =
+        pure $
+          mempty
+            { commandLine =
+                mempty
+                  { keyBased =
+                      fromList
+                        [ ("--no-locale", Nothing),
+                          ("--encoding=", Just "UTF8")
+                        ]
+                  }
+            },
+      -- , postgresConfig = mempty
+      --     { commandLine = mempty
+      --         { keyBased = fromList
+      --         [ ("--no-locale", Nothing)
+      --         , ("--encoding=", Just "UTF8")
+      --         ]
+      --         }
+      --     }
+      dataDirectory = Permanent ".pg",
+      port = Last (Just $ Just 5432),
+      connectionOptions =
+        mempty
+          { host = pure "localhost",
+            user = pure user
+          }
+    }
+
+databaseDumpDir = "database_dumps"
+
+migrateArchiveDumpBackup :: PG.Connection -> IO ()
+migrateArchiveDumpBackup conn = do
+  putStrLn "Initializing a temporary Archive Database!"
+  putStr "Enter a Mina Network to get started: "
+  network :: MinaNetwork <- getLine <&> read
+  filenames <- getDirectoryContents databaseDumpDir
+  let archiveDumps 
+        = reverse 
+        . sort 
+        . filter (\dump -> network == 
+            (dumpNetwork . dumpMetadata) dump) 
+        $ parseDumps filenames
+  let (ArchiveDump targetKey metadata) : dumps = archiveDumps
+
+  let archiveDumpFilename = databaseDumpDir ++ "/" ++ targetKey
+  execute_ conn "CREATE DATABASE archive;"
+  execute_ conn "CREATE DATABASE archive_balances_migrated"
+
+  --   putStr "would you like to restore the latest archive backup? (y/N) "
+  --   restore <- getLine
+  --   when (restore == "y") $
+  restoreDatabaseBackup archiveDumpFilename
+
+withConnection :: PG.Connection -> IO ()
+withConnection conn = do
+  putStrLn "creating archive and archive_balances_migrated databases..."
+  migrateArchiveDumpBackup conn
+  putStrLn "entering idle..."
+  databaseLoop
+
+databaseLoop :: IO ()
+databaseLoop = do
+  databaseLoop
+
+shutdownDatabase :: PG.Connection -> IO ()
+shutdownDatabase conn = do
+  putStrLn "closing databse connection..."
+  close conn
+  putStrLn "removing temporary database files..."
+  removeDirectoryRecursive ".pg"
+
+main :: IO ()
+main = do
+  config <- databaseConfig
+  res <- withConfig config $ \db ->
+    bracket
+      (connectPostgreSQL (toConnectionString db))
+      shutdownDatabase
+      withConnection
+  case res of
+    Left r -> print r
+    Right _ -> pure ()

--- a/tools/shell.nix
+++ b/tools/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    bash
+    haskell-language-server
+    rnix-lsp nixpkgs-fmt
+    geos gdal
+    (postgresql.withPackages (p: [ p.postgis ]))
+    (haskellPackages.ghcWithPackages (self: with haskellPackages; [
+      effectful curl xml tar zlib megaparsec bytestring directory tmp-postgres json process hlint
+    ]))
+  ];
+
+  shellHook = ''
+  '';
+}


### PR DESCRIPTION
Re-adds and upgrades the archive node tools from the `archive/nix` branch to improve CI and DX when working with this repository. run `nix-shell -p tools/shell.nix` to enter the development environment and then run `runghc tools/DownloadArchiveDump.hs` and enter a network to download the latest archive dump for that network or run `runghc tools/TemporaryArchiveDatabase.hs` to provision and run a local postgres database using an archive dump